### PR TITLE
psi_ft in the cwt method needs to be conjugated.

### DIFF
--- a/wavelet.py
+++ b/wavelet.py
@@ -304,7 +304,7 @@ def cwt(signal, dt, dj=0.25, s0=-1, J=-1, wavelet=Morlet()):
     # scale using the convolution theorem.
     W = zeros((len(sj), N), 'complex')
     for n, s in enumerate(sj):
-        psi_ft_bar = (s * ftfreqs[1] * N) ** .5 * wavelet.psi_ft(s * ftfreqs)
+        psi_ft_bar = (s * ftfreqs[1] * N) ** .5 * conjugate(wavelet.psi_ft(s * ftfreqs))
         W[n, :] = ifft(signal_ft * psi_ft_bar, N)
 
     # Checks for NaN in transform results and removes them from the scales,


### PR DESCRIPTION
Hi,

Thanks for converting the Torrence and Compo (1998) paper into Python.  I am very grateful for the code.  I spotted an error in the cwt method.  According to Torrence and Compo (1998), equation (4), the conjugate of the psi_ft should be used, not a plain psi_ft.  I spotted this because the wavelet transform arising from the DOG wavelet transform (as implemented in the regeirk/kPyWavelet repository) is not exactly real (to within numerical precision).  The fix is simply to conjugate the psi_ft.

Thanks again for the code!
