### PR TITLE
fix cwt extra return values bug, refactor kwargs

### DIFF
--- a/pycwt/sample/sample_xwt.py
+++ b/pycwt/sample/sample_xwt.py
@@ -93,13 +93,11 @@ mother = wavelet.Morlet(6)           # Morlet mother wavelet with m=6
 # The following routines perform the wavelet transform and siginificance
 # analysis for two data sets.
 
-W1, scales1, freqs1, coi1 = wavelet.cwt(s1/std1, dt, dj, s0,
-                                                         J,mother)
+W1, scales1, freqs1, coi1, _, _ = wavelet.cwt(s1/std1, dt, dj, s0, J, mother)
 signif1, fft_theor1 = wavelet.significance(1.0, dt, scales1, 0, alpha1,
                                            significance_level=slevel,
                                            wavelet=mother)
-W2, scales2, freqs2, coi2 = wavelet.cwt(s2/std2, dt, dj, s0,
-                                                         J,mother)
+W2, scales2, freqs2, coi2, _, _ = wavelet.cwt(s2/std2, dt, dj, s0, J, mother)
 signif2, fft_theor2 = wavelet.significance(1.0, dt, scales2, 0, alpha2,
                                            significance_level=slevel,
                                            wavelet=mother)


### PR DESCRIPTION
In 89ff93 the two extra cwt args (signal_ft, ft_freqs) were removed from
calls, but cwt() still returns them.

Keyword arguments repetitively passed to cwt() were refactored using
**kwargs_dict style argument unpacking.