### PR TITLE
use pyfftw if available, vectorize FFT for loops

### DIFF
--- a/pycwt/helpers.py
+++ b/pycwt/helpers.py
@@ -7,11 +7,11 @@ try:                            # pyfftw wrapper for FFTW
     from multiprocessing import cpu_count
     _FFTW_KWARGS_DEFAULT = {'planner_effort': 'FFTW_ESTIMATE', # fast planning
                             'threads': cpu_count(), # use all available threads
-                            'n': None, # do not pad
                             }
     def fft_kwargs(signal, **kwargs):
         '''Return optimized keyword arguments for FFTW'''
         kwargs.update(_FFTW_KWARGS_DEFAULT)
+        kwargs['n'] = len(signal) # do not pad
         return kwargs
 except ImportError:             # fall back to 2^n padded scipy FFTPACK
     import scipy.fftpack as fftmod

--- a/pycwt/mothers.py
+++ b/pycwt/mothers.py
@@ -2,12 +2,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-import scipy.fftpack as fft
 from scipy.special import gamma
 from scipy.signal import convolve2d
 from scipy.special.orthogonal import hermitenorm
 
-from .helpers import rect
+from .helpers import rect, fftmod, fft_kwargs
 
 class Morlet(object):
     """
@@ -65,18 +64,19 @@ class Morlet(object):
         # Webster (1999) and bry Grinsted et al. (2004).
 
         m, n = W.shape
-        T = np.zeros([m, n])
 
         # Filter in time.
-        npad = int(2 ** np.ceil(np.log2(n)))
-        k = 2 * np.pi * fft.fftfreq(npad)
+        k = 2 * np.pi * fftmod.fftfreq(fft_kwargs(W[0,:]))
         k2 = k ** 2
         snorm = scales / dt
-
-        for i in range(m):
-            F = np.exp(-0.5 * (snorm[i] ** 2) * k2)
-            smooth = fft.ifft(F * fft.fft(W[i, :], npad))
-            T[i, :] = smooth[0:n]
+        # smoothing by Gaussian window (absolute value of wavelet function)
+        # using the convolution theorem: multiplication by Gaussian curve in
+        # Fourier domain for each scale, outer product of scale and frequency
+        F = np.exp(-0.5 * (snorm[:,np.newaxis] ** 2) * k2) # outer product
+        smooth = fftmod.ifft(F * fftmod.fft(W, axis=1, **fft_kwargs(W[0,:])),
+                             axis=1, # along Fourier frequencies
+                             **fft_kwargs(W[0,:], overwrite_x=True))
+        T = smooth[:,:n]        # remove possibly padded region due to FFT
 
         if np.isreal(W).all():
             T = T.real
@@ -85,7 +85,7 @@ class Morlet(object):
         # 0.6 width.
         wsize = self.deltaj0 / dj * 2
         win = rect(np.int(np.round(wsize)), normalize=True)
-        T = convolve2d(T, win[:, None], 'same')
+        T = convolve2d(T, win[:,np.newaxis], 'same') # scales are "vertical"
 
         return T
 

--- a/pycwt/mothers.py
+++ b/pycwt/mothers.py
@@ -66,7 +66,7 @@ class Morlet(object):
         m, n = W.shape
 
         # Filter in time.
-        k = 2 * np.pi * fftmod.fftfreq(fft_kwargs(W[0,:]))
+        k = 2 * np.pi * fftmod.fftfreq(fft_kwargs(W[0,:])['n'])
         k2 = k ** 2
         snorm = scales / dt
         # smoothing by Gaussian window (absolute value of wavelet function)


### PR DESCRIPTION
Rationale:

FFTW is a usually lot faster than FFTPACK in scipy and does not need
padding which is often a problem with larger signals.

FFT implementation selection and configuration:

The (presumably) fastest FFT backend is chosen during importing in
helpers.py and fft_kwargs() offers a transparent interface for
implementation-specific settings. Some of those settings can be
configured using global variables in helpers.py.

Vectorization of FFT for loops:

Using the axis parameter the FFT can be calculated only along a
specified axis, e.g. for all rows at once. Multiplication along
different axes is vectorized using broadcasting rules for outer product.