### PR TITLE
use six

### DIFF
--- a/pycwt/wavelet.py
+++ b/pycwt/wavelet.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import six
 
 import os
 
@@ -71,7 +72,7 @@ def cwt(signal, dt, dj=1/12, s0=-1, J=-1, wavelet='morlet'):
            0.25, 0.25, 0.5, 28, mother)
 
     """
-    if isinstance(wavelet, unicode) or isinstance(wavelet, str):
+    if isinstance(wavelet, six.string_types):
         wavelet = mothers[wavelet]()
 
     # Original signal length.
@@ -153,7 +154,7 @@ def icwt(W, sj, dt, dj=1/12, wavelet='morlet'):
     >> iwave = wavelet.icwt(wave, scales, 0.25, 0.25, mother)
 
     """
-    if isinstance(wavelet, unicode) or isinstance(wavelet, str):
+    if isinstance(wavelet, six.string_types):
         wavelet = mothers[wavelet]()
 
     a, b = W.shape
@@ -226,7 +227,7 @@ def significance(signal, dt, scales, sigma_test=0, alpha=None,
         Theoretical red-noise spectrum as a function of period.
 
     """
-    if isinstance(wavelet, unicode) or isinstance(wavelet, str):
+    if isinstance(wavelet, six.string_types):
         wavelet = mothers[wavelet]()
 
     try:
@@ -367,7 +368,7 @@ def xwt(signal, signal2, dt, dj=1/12, s0=-1, J=-1, significance_level=0.95,
         Significance levels as a function of scale.
 
     """
-    if isinstance(wavelet, unicode) or isinstance(wavelet, str):
+    if isinstance(wavelet, six.string_types):
         wavelet = mothers[wavelet]()
 
     # Defines some parameters like length of both time-series, time step
@@ -454,7 +455,7 @@ def wct(signal, signal2, dt, dj=1/12, s0=-1, J=-1, sig=True, significance_level=
     wavelet.cwt, wavelet.xwt
 
     """
-    if isinstance(wavelet, unicode) or isinstance(wavelet, str):
+    if isinstance(wavelet, six.string_types):
         wavelet = mothers[wavelet]()
 
     if s0 == -1: s0 = 2 * dt / wavelet.flambda()  # Smallest resolvable scale


### PR DESCRIPTION
When I use your library with Python 3.5.2, the error "unicode is not defined" at wavelet.py were raised. This PR will replace `unicode` to `six.string_types` and work on Python3.5.2.