### PR TITLE
Replaced progressbar module with tqdm, which supports Python 3 and is better maintained

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license='BSD',
     url='https://github.com/regeirk/pycwt',
     packages=['pycwt'],
-    install_requires=['numpy', 'scipy', 'matplotlib', 'progressbar'],
+    install_requires=['numpy', 'scipy', 'matplotlib', 'tqdm'],
     long_description=read('README.txt'),
     keywords=['wavelet', 'spectral analysis', 'signal processing',
               'data science'],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/regeirk/pycwt',
     packages=['pycwt'],
     install_requires=['numpy', 'scipy', 'matplotlib', 'tqdm'],
-    long_description=read('README.txt'),
+    long_description=read('README.md'),
     keywords=['wavelet', 'spectral analysis', 'signal processing',
               'data science'],
     classifiers=[


### PR DESCRIPTION
I use Python 3 and tried to install pycwt over pip. It failed because it tried to install progressbar, which is outdated and supports only python 2x. I went over the code and replaced progressbar with tqdm, which is superior and better maintained--and more importantly is python 3x compatible. I did not touch any other part of the code, only the parts related to displaying a progress bar.