### PR TITLE
Mistake in the inverse wavelet transform

### DIFF
--- a/pycwt/wavelet.py
+++ b/pycwt/wavelet.py
@@ -166,7 +166,7 @@ def icwt(W, sj, dt, dj=1/12, wavelet='morlet'):
         raise Warning('Input array dimensions do not match.')
 
     # As of Torrence and Compo (1998), eq. (11)
-    iW = (dj * np.sqrt(dt) / wavelet.cdelta * wavelet.psi(0) *
+    iW = (dj * np.sqrt(dt) / (wavelet.cdelta * wavelet.psi(0)) *
           (np.real(W) / sj).sum(axis=0))
     return iW
 


### PR DESCRIPTION
https://github.com/ymarcon1/pycwt/blob/1bef44e7673ea5109f569e77195e70ce99016b26/pycwt/wavelet.py#L168-L170

According to equation 11 from Torrence and Compo (1998) this code should look like this:
`iW = (dj * np.sqrt(dt) / (wavelet.cdelta * wavelet.psi(0)) * (np.real(W) / sj).sum(axis=0))`
