### PR TITLE
updating the deprecated np.int

### DIFF
--- a/pycwt/helpers.py
+++ b/pycwt/helpers.py
@@ -27,7 +27,7 @@ except ImportError:
     def fft_kwargs(signal, **kwargs):
         """Return next higher power of 2 for given signal to speed up FFT"""
         if _FFT_NEXT_POW2:
-            return {'n': np.int(2 ** np.ceil(np.log2(len(signal))))}
+            return {'n': int(2 ** np.ceil(np.log2(len(signal))))}
 
 from scipy.signal import lfilter
 from os import makedirs
@@ -220,7 +220,7 @@ def boxpdf(x):
 
     j = np.concatenate([[0], j + 1])
     Y = 0.5 * (j[0:-1] + j[1:]) / n
-    bX = np.interp(x, X, Y)
+    bX = interp(x, X, Y)
 
     return bX, X, Y
 

--- a/pycwt/mothers.py
+++ b/pycwt/mothers.py
@@ -98,7 +98,7 @@ class Morlet(object):
         # Filter in scale. For the Morlet wavelet it's simply a boxcar with
         # 0.6 width.
         wsize = self.deltaj0 / dj * 2
-        win = rect(np.int(np.round(wsize)), normalize=True)
+        win = rect(int(np.round(wsize)), normalize=True)
         T = convolve2d(T, win[:, np.newaxis], 'same')  # Scales are "vertical"
 
         return T

--- a/pycwt/wavelet.py
+++ b/pycwt/wavelet.py
@@ -1,4 +1,4 @@
-"""PyCWT core wavelet transform functions."""
+int"""PyCWT core wavelet transform functions."""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
@@ -78,7 +78,7 @@ def cwt(signal, dt, dj=1/12, s0=-1, J=-1, wavelet='morlet', freqs=None):
             s0 = 2 * dt / wavelet.flambda()
         # Number of scales
         if J == -1:
-            J = np.int(np.round(np.log2(n0 * dt / s0) / dj))
+            J = int(np.round(np.log2(n0 * dt / s0) / dj))
         # The scales as of Mallat 1999
         sj = s0 * 2 ** (np.arange(0, J + 1) * dj)
         # Fourier equivalent frequencies
@@ -477,7 +477,7 @@ def wct(y1, y2, dt, dj=1/12, s0=-1, J=-1, sig=True,
         s0 = 2 * dt / wavelet.flambda()
     if J == -1:
         # Number of scales
-        J = np.int(np.round(np.log2(y1.size * dt / s0) / dj))
+        J = int(np.round(np.log2(y1.size * dt / s0) / dj))
 
     # Makes sure input signals are numpy arrays.
     y1 = np.asarray(y1)


### PR DESCRIPTION
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. 